### PR TITLE
Update GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -28,7 +28,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -40,7 +40,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
Every action in both workflows was pinned to a Node 20 release. GitHub has deprecated Node 20 on Actions runners, so these are force-run on Node 24 and emit a warning on every run.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `oven-sh/setup-bun` | v1 | v2 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/build-push-action` | v5 | v7 |

`build.yml` covers the first two, `docker.yml` the rest.

No workflow logic changed — only the `uses:` pins. All inputs currently passed (`bun-version`, `registry`/`username`/`password`, `images`/`tags`, `context`/`push`/`tags`/`labels`/`cache-from`/`cache-to`/`platforms`) are unchanged and still supported in the new majors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcHjREt3QE8KrMSdJU9FJm)_