### PR TITLE
Proxy API requests through Vite preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,14 @@ WORKDIR /app
 # Copy built artifacts and dependencies
 COPY --from=builder /app/server/dist ./server/dist
 COPY --from=builder /app/client/dist ./client/dist
+COPY --from=builder /app/client/vite.config.ts ./client/vite.config.ts
 COPY --from=builder /app/node_modules ./node_modules
 COPY package.json .
 COPY client/package.json ./client/
 COPY server/package.json ./server/
 
-# Expose ports for client and server
-EXPOSE 8579 8580
+# Only the Vite preview server is public; it proxies /api to the backend.
+EXPOSE 8580
 
 # Start both applications using concurrently
 CMD ["bun", "run", "start"]
-

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ services:
       - 8580:8580
     environment:
       - REDIS_URL=redis://redis:6379
-      # Allow Vite Preview to serve the app through this reverse-proxy hostname.
-      - __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=portfolio.nuc.gregskril.com
+      # Use this if you visit your local server from a different hostname
+      # - __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=
     depends_on:
       - redis
     volumes:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ services:
       - 8580:8580
     environment:
       - REDIS_URL=redis://redis:6379
-      # Use this if you visit your local server from a different hostname
-      # - __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=
+      # Allow Vite Preview to serve the app through this reverse-proxy hostname.
+      - __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=portfolio.nuc.gregskril.com
     depends_on:
       - redis
     volumes:

--- a/client/src/hooks/useHono.ts
+++ b/client/src/hooks/useHono.ts
@@ -4,8 +4,7 @@ import { Client } from 'server/hc'
 
 import { useQueues } from './useQueues'
 
-const url = new URL(window.location.origin)
-export const SERVER_URL = url.protocol + '//' + url.hostname + ':8579'
+export const SERVER_URL = '/api'
 
 export const honoClient: Client = hc(SERVER_URL) as unknown as Client
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,8 +3,22 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 import { defineConfig } from 'vite'
 
+const apiProxy = {
+  '/api': {
+    target: 'http://127.0.0.1:8579',
+    changeOrigin: true,
+    rewrite: (requestPath: string) => requestPath.replace(/^\/api/, ''),
+  },
+}
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: apiProxy,
+  },
+  preview: {
+    proxy: apiProxy,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - '8579:8579' # Server port
       - '8580:8580' # Client port
     volumes:
       - sqlite_data:/app/data
     environment:
       - REDIS_URL=redis://redis:6379
       - NODE_ENV=production
+      - __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=portfolio.nuc.gregskril.com
     command: bun run start
     depends_on:
       redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379
       - NODE_ENV=production
-      - __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=portfolio.nuc.gregskril.com
     command: bun run start
     depends_on:
       redis:


### PR DESCRIPTION
## Summary

- route browser API requests through the same-origin `/api` path
- proxy `/api` through Vite dev and preview to the Hono backend on port 8579
- include the Vite config in the runtime image and stop publishing the backend port

## Verification

- `bun run build:client`
- `bun run --cwd client lint` (passes with one pre-existing Fast Refresh warning)
- `docker compose config --quiet`
- integration request confirmed `/api/accounts?type=offchain` returns HTTP 200 and reaches the backend as `/accounts`

A complete local Docker image build was not run because the local OrbStack/Docker daemon was unavailable.