### PR TITLE
Proxy BullMQ dashboard assets through Vite

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,21 +3,27 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 import { defineConfig } from 'vite'
 
-const apiProxy = {
+const backendTarget = 'http://127.0.0.1:8579'
+
+const backendProxy = {
   '/api': {
-    target: 'http://127.0.0.1:8579',
+    target: backendTarget,
     changeOrigin: true,
     rewrite: (requestPath: string) => requestPath.replace(/^\/api/, ''),
+  },
+  '/dashboard': {
+    target: backendTarget,
+    changeOrigin: true,
   },
 }
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
-    proxy: apiProxy,
+    proxy: backendProxy,
   },
   preview: {
-    proxy: apiProxy,
+    proxy: backendProxy,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- proxy BullMQ’s `/dashboard` route through Vite to the Hono backend
- preserve the existing `/api` rewrite while sharing the backend target
- allow dashboard scripts and styles emitted under `/dashboard/static` to load correctly

## Verification

- `bun run build:client`
- `bun run --cwd client lint` (passes with one pre-existing Fast Refresh warning)
- integration proxy checks:
  - `/api/accounts` reached `/accounts`
  - `/api/dashboard` reached `/dashboard`
  - `/dashboard/static/js/main.js` reached the backend unchanged