### PR TITLE
Update dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "local-eth-accounting",
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
-        "bun-types": "latest",
+        "bun-types": "1.3.14",
         "concurrently": "^9.2.4",
         "prettier-plugin-tailwindcss": "^0.6.14",
       },
@@ -72,13 +72,9 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
-        "@types/bun": "latest",
+        "@types/bun": "1.3.14",
       },
     },
-  },
-  "overrides": {
-    "flatted": "^3.4.4",
-    "lodash": "^4.17.23",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
@@ -399,7 +395,7 @@
 
     "bullmq": ["bullmq@5.81.3", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.11.1", "msgpackr": "2.0.5", "node-abort-controller": "3.1.1", "semver": "7.8.5", "tslib": "2.8.1" }, "peerDependencies": { "redis": ">=5.0.0" }, "optionalPeers": ["redis"] }, "sha512-Q7uEH2G92rVjX3Yl2qw3+6VEO15uxehC6DfeTHQBQTehddcRDSDuquD9zuvDjxiCffXsPUaBwrRlvlbVcgKs7g=="],
 
-    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001717", "", {}, "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw=="],
 
@@ -859,11 +855,7 @@
 
     "@types/better-sqlite3/@types/node": ["@types/node@22.15.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
-
-    "bun-types/@types/node": ["@types/node@22.15.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -944,8 +936,6 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
-
-    "@types/bun/bun-types/@types/node": ["@types/node@22.15.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw=="],
 
     "eslint-plugin-react-hooks/@babel/parser/@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -21,15 +21,11 @@
   ],
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
-    "bun-types": "latest",
+    "bun-types": "1.3.14",
     "concurrently": "^9.2.4",
     "prettier-plugin-tailwindcss": "^0.6.14"
   },
   "peerDependencies": {
     "typescript": "^5.9.3"
-  },
-  "overrides": {
-    "flatted": "^3.4.4",
-    "lodash": "^4.17.23"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "@types/bun": "latest"
+    "@types/bun": "1.3.14"
   }
 }


### PR DESCRIPTION
## Summary

Scheduled dependency audit across root, `server/`, and `client/`. `bun audit` reports **no vulnerabilities** anywhere in the tree (the previous hardening pass in #18 already cleaned this up), so this pass is cleanup + one stability fix rather than security patching.

| Change | Before → After | Type | Why |
|---|---|---|---|
| `overrides` block (root) | `{flatted: ^3.4.4, lodash: ^4.17.23}` → **removed** | cleanup | Re-verified both: `flatted` resolves to `3.4.4` on its own via `flat-cache`'s `^3.2.9` range (pulled in by `eslint@10.8.1` → `file-entry-cache`), and `lodash` resolves to `4.18.1` on its own via `recharts`/`@bull-board/api`/`@trivago/prettier-plugin-sort-imports`'s existing `^4.17.x` ranges. Removed the overrides and reinstalled — identical resolved versions, zero other lockfile changes. No longer needed. |
| `bun-types` (root), `@types/bun` (server) | `"latest"` → `"1.3.14"` | stability fix | Found while testing the override removal: a plain `bun install` that needs to re-resolve anything can silently bump `bun-types` past whatever's in the lockfile, because `"latest"` is a floating dist-tag, not a version range the lockfile can pin against. It just moved `1.3.14` → `1.4.0`, which changed the global `Response` type shape enough that `client`'s Hono RPC calls (`ClientResponse<...>` no longer assignable to `Response`, missing `textStream`) failed to typecheck — with no `package.json` diff to explain why. Pinned both to `1.3.14`, which also matches the `packageManager: "bun@1.3.14"` field already declared at the repo root, so this is really just making the intent explicit rather than a version choice. |

## Evaluated but not changed

No CVEs surfaced for anything below, so per policy these are skipped as trivial patch/minor bumps with no documented meaningfully significant fix:
- `server`: `@bull-board/api`/`@bull-board/hono` 8.6.1 → 9.4.0 (major), `bullmq` 5.81.3 → 6.2.0 (major), `ioredis` 5.11.1 → 6.0.0 (major), `kysely` 0.28.17 → 0.29.5 (minor), `kysely-bun-worker` 1.2.1 → 2.0.1 (major), `croner` 9.0.0 → 9.1.0/10.0.1, `hono` 4.13.0 → 4.13.3, `viem` 2.55.15 → 2.55.19, `zod` 3.24.4 → 3.25.76/4.4.3 (major latest)
- `client`: `@tanstack/react-query` 5.101.4 → 5.102.0, `hono` 4.13.0 → 4.13.3, `lucide-react` 0.511.0 → 1.33.0 (major), `recharts` 2.15.4 → 3.10.1 (major), `zod-form-data` 2.0.10 → 3.0.3 (major), `eslint` 10.8.1 → 10.9.0, `globals`, `@types/node`, `typescript` (major "tsgo" rewrite at 7.0.2, not a drop-in)
- root: `@trivago/prettier-plugin-sort-imports`, `concurrently`, `prettier-plugin-tailwindcss` (all dev-only, patch/minor)

## Test plan
- [x] `bun install` (clean lockfile regen, `postinstall`/server build succeeds)
- [x] `bun why flatted` / `bun why lodash` before/after override removal — same resolved versions
- [x] `bun run build:server` — passes
- [x] `bun run build:client` — failed on `bun-types@1.4.0` drift, passes again after pinning to `1.3.14`
- [x] `bun run --cwd client lint` — passes
- [x] `bun audit` — no vulnerabilities, before and after

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFdmZo8U8c2Nr7yn4qE8mf)_