### PR TITLE
Add account tags and portfolio filtering

### DIFF
--- a/client/src/components/AccountCard.tsx
+++ b/client/src/components/AccountCard.tsx
@@ -54,6 +54,7 @@ export function AccountCard() {
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead>Description</TableHead>
+              <TableHead>Tags</TableHead>
               <TableHead>Address</TableHead>
               <TableHead className="text-right">Actions</TableHead>
             </TableRow>
@@ -63,6 +64,18 @@ export function AccountCard() {
               <TableRow key={account.id}>
                 <TableCell>{account.name}</TableCell>
                 <TableCell>{account.description}</TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {account.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="bg-secondary text-secondary-foreground rounded-full px-2 py-0.5 text-xs"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </TableCell>
                 <TableCell>{account.address}</TableCell>
 
                 <TableCell className="flex justify-end gap-2">
@@ -119,6 +132,7 @@ const addAccountSchema = zfd.formData({
   name: zfd.text(z.string().optional()),
   description: zfd.text(z.string().optional()),
   addressOrName: zfd.text(z.string().optional()),
+  tags: zfd.text(z.string().optional()),
 })
 
 function AccountDialog({
@@ -146,7 +160,18 @@ function AccountDialog({
       return
     }
 
-    const json = safeParse.data
+    const { tags, ...account } = safeParse.data
+    const json = {
+      ...account,
+      tags: [
+        ...new Set(
+          (tags ?? '')
+            .split(',')
+            .map((tag) => tag.trim().toLowerCase())
+            .filter(Boolean)
+        ),
+      ],
+    }
     const promise = honoClient.accounts
       .$post({ json })
       .then(throwIfNotOk)
@@ -223,6 +248,22 @@ function AccountDialog({
               name="description"
               autoComplete="off"
               defaultValue={selectedAccount?.description ?? ''}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="tags">
+              Tags{' '}
+              <span className="text-muted-foreground text-xs leading-none">
+                (comma-separated)
+              </span>
+            </Label>
+            <Input
+              id="tags"
+              name="tags"
+              placeholder="business, personal"
+              autoComplete="off"
+              defaultValue={selectedAccount?.tags.join(', ')}
             />
           </div>
 

--- a/client/src/components/PortfolioCard.tsx
+++ b/client/src/components/PortfolioCard.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, RefreshCcwIcon } from 'lucide-react'
-import { Fragment, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useQueues } from '@/hooks/useQueues'
@@ -8,12 +8,20 @@ import { useCurrency } from '../hooks/useCurrency'
 import {
   honoClient,
   throwIfNotOk,
+  useAccounts,
   useBalances,
   useFiat,
 } from '../hooks/useHono'
 import { formatCurrency, toFixed } from '../lib/utils'
 import { Button } from './ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select'
 import {
   Table,
   TableBody,
@@ -26,9 +34,62 @@ import {
 
 export function PortfolioCard() {
   const balances = useBalances()
+  const accounts = useAccounts()
   const { currency } = useCurrency()
   const { data: fiat } = useFiat()
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
+  const [selectedTag, setSelectedTag] = useState('all')
+
+  const tags = useMemo(
+    () =>
+      [
+        ...new Set(accounts.data?.flatMap((account) => account.tags) ?? []),
+      ].sort(),
+    [accounts.data]
+  )
+
+  const filteredPortfolio = useMemo(() => {
+    if (!balances.data) return undefined
+    if (selectedTag === 'all') return balances.data
+
+    const accountIds = new Set(
+      accounts.data
+        ?.filter((account) => account.tags.includes(selectedTag))
+        .map((account) => account.id) ?? []
+    )
+
+    const tokens = balances.data.tokens
+      .map((token) => {
+        const accountBreakdown = token.accountBreakdown.filter((item) =>
+          accountIds.has(item.account.id)
+        )
+        const balance = accountBreakdown.reduce(
+          (total, item) => total + item.balance,
+          0
+        )
+        const ethValue = accountBreakdown.reduce(
+          (total, item) => total + item.ethValue,
+          0
+        )
+
+        return {
+          ...token,
+          balance,
+          ethValue,
+          accountBreakdown: accountBreakdown.map((item) => ({
+            ...item,
+            percentage: (item.balance / balance) * 100,
+          })),
+        }
+      })
+      .filter((token) => token.balance > 0)
+
+    return {
+      ...balances.data,
+      tokens,
+      totalEthValue: tokens.reduce((total, token) => total + token.ethValue, 0),
+    }
+  }, [accounts.data, balances.data, selectedTag])
 
   const toggleRow = (tokenId: number) => {
     setExpandedRows((prev) => {
@@ -44,9 +105,24 @@ export function PortfolioCard() {
 
   return (
     <Card>
-      <CardHeader className="flex items-center justify-between gap-2">
+      <CardHeader className="flex flex-wrap items-center justify-between gap-2">
         <CardTitle>Multichain Portfolio </CardTitle>
-        <RefreshPortfolioButton />
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={selectedTag} onValueChange={setSelectedTag}>
+            <SelectTrigger className="w-44" aria-label="Filter holdings by tag">
+              <SelectValue placeholder="Filter by tag" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All tags</SelectItem>
+              {tags.map((tag) => (
+                <SelectItem key={tag} value={tag}>
+                  {tag}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <RefreshPortfolioButton />
+        </div>
       </CardHeader>
 
       <CardContent className="flex flex-col gap-2">
@@ -62,7 +138,7 @@ export function PortfolioCard() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {balances.data?.tokens.map((token) => {
+            {filteredPortfolio?.tokens.map((token) => {
               const isExpanded = expandedRows.has(token.id)
 
               return (
@@ -98,7 +174,8 @@ export function PortfolioCard() {
                     <TableCell
                       className="text-right"
                       title={`${toFixed(
-                        (token.ethValue / balances.data?.totalEthValue) * 100,
+                        (token.ethValue / filteredPortfolio.totalEthValue) *
+                          100,
                         2
                       )}% of net value`}
                     >
@@ -148,6 +225,16 @@ export function PortfolioCard() {
                 </Fragment>
               )
             })}
+            {filteredPortfolio?.tokens.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-muted-foreground py-8 text-center"
+                >
+                  No holdings found for the selected tag.
+                </TableCell>
+              </TableRow>
+            )}
           </TableBody>
           <TableFooter>
             <TableRow>
@@ -156,7 +243,7 @@ export function PortfolioCard() {
                 {fiat &&
                   currency &&
                   formatCurrency(
-                    (balances.data?.totalEthValue ?? 0) /
+                    (filteredPortfolio?.totalEthValue ?? 0) /
                       fiat.getRate(currency),
                     currency
                   )}

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -26,6 +26,11 @@ interface AccountRow {
   createdAt: GeneratedAlways<Date>
 }
 
+interface AccountTagRow {
+  accountId: number // AccountRow['id']
+  tag: string
+}
+
 interface TokenRow {
   id: GeneratedAlways<number>
   address: Address
@@ -53,6 +58,7 @@ interface NetworthRow {
 
 export type Tables = {
   accounts: AccountRow
+  accountTags: AccountTagRow
   chains: ChainRow
   tokens: TokenRow
   balances: BalanceRow

--- a/server/src/db/migrations/004_account_tags.ts
+++ b/server/src/db/migrations/004_account_tags.ts
@@ -1,0 +1,16 @@
+import { Kysely } from 'kysely'
+
+export const up = async (db: Kysely<any>) => {
+  await db.schema
+    .createTable('accountTags')
+    .addColumn('accountId', 'integer', (col) =>
+      col.references('accounts.id').onDelete('cascade').notNull()
+    )
+    .addColumn('tag', 'text', (col) => col.notNull())
+    .addPrimaryKeyConstraint('account_tags_pkey', ['accountId', 'tag'])
+    .execute()
+}
+
+export const down = async (db: Kysely<any>) => {
+  await db.schema.dropTable('accountTags').execute()
+}

--- a/server/src/db/migrator.ts
+++ b/server/src/db/migrator.ts
@@ -7,8 +7,9 @@ import type { MigrationProvider } from 'kysely'
 import * as m1 from './migrations/001_initial_migrations'
 import * as m2 from './migrations/002_erc4626'
 import * as m3 from './migrations/003_usd_networth'
+import * as m4 from './migrations/004_account_tags'
 
-const migrations = [m1, m2, m3]
+const migrations = [m1, m2, m3, m4]
 
 export const migrator: MigrationProvider = {
   async getMigrations() {

--- a/server/src/handlers/accounts.ts
+++ b/server/src/handlers/accounts.ts
@@ -1,15 +1,30 @@
 import type { Context } from 'hono'
-import type { BlankEnv } from 'hono/types'
-import { type Address, isAddress } from 'viem'
+import type { Transaction } from 'kysely'
+import { isAddress } from 'viem'
 import { z } from 'zod'
 
 import { getViemClient } from '../chains'
-import { db } from '../db'
+import { type Tables, db } from '../db'
 import { truncateAddress } from '../utils'
 
 const getAccountsSchema = z.object({
   type: z.enum(['onchain', 'offchain']).optional(),
 })
+
+const tagSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(32)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9 _-]*$/, {
+    message:
+      'Tags may only contain letters, numbers, spaces, hyphens, and underscores',
+  })
+
+const tagsSchema = z
+  .array(tagSchema)
+  .max(20)
+  .transform((tags) => [...new Set(tags.map((tag) => tag.toLowerCase()))])
 
 export async function getAccounts(c: Context) {
   const safeParse = getAccountsSchema.safeParse(c.req.query())
@@ -41,7 +56,17 @@ export async function getAccounts(c: Context) {
       accounts = await db.selectFrom('accounts').selectAll().execute()
   }
 
-  return c.json(accounts)
+  const accountTags = await db.selectFrom('accountTags').selectAll().execute()
+
+  return c.json(
+    accounts.map((account) => ({
+      ...account,
+      tags: accountTags
+        .filter((accountTag) => accountTag.accountId === account.id)
+        .map((accountTag) => accountTag.tag)
+        .sort(),
+    }))
+  )
 }
 
 // Maybe will be relevant in the future but we don't need it right now
@@ -66,11 +91,30 @@ export async function getAccounts(c: Context) {
 // }
 
 const addAccountSchema = z.object({
-  id: z.coerce.number().optional(),
+  id: z.coerce.number().int().positive().optional(),
   addressOrName: z.string().optional(),
   name: z.string().optional(),
   description: z.string().optional(),
+  tags: tagsSchema.optional().default([]),
 })
+
+async function replaceAccountTags(
+  trx: Transaction<Tables>,
+  accountId: number,
+  tags: string[]
+) {
+  await trx
+    .deleteFrom('accountTags')
+    .where('accountId', '=', accountId)
+    .execute()
+
+  if (tags.length > 0) {
+    await trx
+      .insertInto('accountTags')
+      .values(tags.map((tag) => ({ accountId, tag })))
+      .execute()
+  }
+}
 
 export async function addAccount(c: Context) {
   const body = await c.req.json()
@@ -80,7 +124,8 @@ export async function addAccount(c: Context) {
     return c.json({ error: safeParse.error }, 400)
   }
 
-  let { id, addressOrName, name, description } = safeParse.data
+  const { id, description, tags } = safeParse.data
+  let { addressOrName, name } = safeParse.data
 
   if (!addressOrName && !name) {
     return c.json(
@@ -89,28 +134,48 @@ export async function addAccount(c: Context) {
     )
   }
 
-  // Handle offchain accounts
-  if (!addressOrName) {
-    if (id) {
-      // Update an existing offchain account
-      await db
+  if (id) {
+    const account = await db
+      .selectFrom('accounts')
+      .select('id')
+      .where('id', '=', id)
+      .executeTakeFirst()
+
+    if (!account) {
+      return c.json({ error: 'Account not found' }, 404)
+    }
+
+    if (!name) {
+      return c.json({ error: 'Name is required when editing an account' }, 400)
+    }
+
+    await db.transaction().execute(async (trx) => {
+      await trx
         .updateTable('accounts')
-        .set({
-          name,
-          description,
-        })
+        .set({ name, description })
         .where('id', '=', id)
         .execute()
-    } else {
-      // Create a new offchain account
-      await db
+
+      await replaceAccountTags(trx, id, tags)
+    })
+
+    return c.json({ success: true })
+  }
+
+  // Handle offchain accounts
+  if (!addressOrName) {
+    await db.transaction().execute(async (trx) => {
+      const account = await trx
         .insertInto('accounts')
         .values({
           name: name!,
           description,
         })
-        .execute()
-    }
+        .returning('id')
+        .executeTakeFirstOrThrow()
+
+      await replaceAccountTags(trx, account.id, tags)
+    })
 
     return c.json({ success: true })
   }
@@ -154,7 +219,15 @@ export async function addAccount(c: Context) {
     return c.json({ error: 'Account already exists' }, 400)
   }
 
-  await db.insertInto('accounts').values(data).execute()
+  await db.transaction().execute(async (trx) => {
+    const account = await trx
+      .insertInto('accounts')
+      .values(data)
+      .returning('id')
+      .executeTakeFirstOrThrow()
+
+    await replaceAccountTags(trx, account.id, tags)
+  })
 
   return c.json({ success: true })
 }


### PR DESCRIPTION
## Summary

- add normalized, validated tags to onchain and offchain accounts
- show and edit comma-separated tags in the account dialog
- add a portfolio tag selector that recalculates token amounts, values, account percentages, and totals for matching accounts

## Verification

- `bunx prettier --write .`
- `bun run build:client`
- `bun run build:server`
- `cd client && bun run lint`
- Playwright browser flow: add the `personal` tag to `vitalik.eth`, open Portfolio, select `personal`, and assert the filtered Ether amount
